### PR TITLE
RDKEMW-3037: Premerge CI : integrate middleware development layer to image assembler

### DIFF
--- a/export_manifest_path.sh
+++ b/export_manifest_path.sh
@@ -27,6 +27,19 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 repo_forall=$SCRIPT_DIR/repo_forall.sh
 tmp_env_file=$(mktemp)
 repo forall -c "$repo_forall >> $tmp_env_file"
+# Pre-process MANIFEST_PATH_BBLAYERS_TEMPLATE to support dev and feed support in the image assembler
+manifest_lines=$(grep '^export MANIFEST_PATH_BBLAYERS_TEMPLATE=' "$tmp_env_file")
+count=$(echo "$manifest_lines" | wc -l)
+if [ "$count" -gt 1 ]; then
+    chosen_line=$(echo "$manifest_lines" | grep 'meta-rdk-images')
+    if [ -z "$chosen_line" ]; then
+        echo "Bug: Duplicated variable(s) - "
+    else
+        # Remove all existing lines and append only the chosen one
+        sed -i '/^export MANIFEST_PATH_BBLAYERS_TEMPLATE=/d' "$tmp_env_file"
+        echo "$chosen_line" >> "$tmp_env_file"
+    fi
+fi
 duplicated_variables=`cat $tmp_env_file | grep -v 'PATH=' | sed 's|=.*$||g' | sort | uniq -c | grep -v '1 export' | sed 's|^.*export ||g'`
 if [ ! -z "$duplicated_variables" ]; then
   echo

--- a/setup-environment
+++ b/setup-environment
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-#export MW_LAYER_BUILD_TYPE="MW_DEV"
+export MW_LAYER_BUILD_TYPE="MW_DEV"
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ "$0" = "${BASH_SOURCE}" ]; then

--- a/setup-environment
+++ b/setup-environment
@@ -17,6 +17,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
+export MW_LAYER_BUILD_TYPE="MW_DEV"
 
 
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/setup-environment
+++ b/setup-environment
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-#export MW_LAYER_BUILD_TYPE="MW_DEV"
+
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ "$0" = "${BASH_SOURCE}" ]; then

--- a/setup-environment
+++ b/setup-environment
@@ -17,7 +17,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-export MW_LAYER_BUILD_TYPE="MW_DEV"
+
 
 
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/setup-environment
+++ b/setup-environment
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-export MW_LAYER_BUILD_TYPE="MW_DEV"
+#export MW_LAYER_BUILD_TYPE="MW_DEV"
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ "$0" = "${BASH_SOURCE}" ]; then

--- a/setup-environment
+++ b/setup-environment
@@ -158,8 +158,7 @@ esac
 sed -e "s/##DISTRO_CODENAME##/$_DISTRO_CODENAME/g" \
     -i conf/local.conf
 
-export MW_LAYER_BUILD_TYPE="MW_DEV"
-#sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
+sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
 
 #Added to install the debug tool packages
 echo 'RDK_TOOLS_PACKAGES = ""' >> conf/local.conf

--- a/setup-environment
+++ b/setup-environment
@@ -18,6 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
+export MW_LAYER_BUILD_TYPE="MW_DEV"
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ "$0" = "${BASH_SOURCE}" ]; then

--- a/setup-environment
+++ b/setup-environment
@@ -18,6 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
+export MW_LAYER_BUILD_TYPE="MW_DEV"
 
 
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -160,7 +161,7 @@ esac
 sed -e "s/##DISTRO_CODENAME##/$_DISTRO_CODENAME/g" \
     -i conf/local.conf
 
-#sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
+sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
 
 #Added to install the debug tool packages
 echo 'RDK_TOOLS_PACKAGES = ""' >> conf/local.conf

--- a/setup-environment
+++ b/setup-environment
@@ -17,7 +17,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-export MW_LAYER_BUILD_TYPE="MW_DEV"
+#export MW_LAYER_BUILD_TYPE="MW_DEV"
 
 
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/setup-environment
+++ b/setup-environment
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-#export MW_LAYER_BUILD_TYPE="MW_DEV"
+export MW_LAYER_BUILD_TYPE="MW_DEV"
 
 
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/setup-environment
+++ b/setup-environment
@@ -160,7 +160,7 @@ esac
 sed -e "s/##DISTRO_CODENAME##/$_DISTRO_CODENAME/g" \
     -i conf/local.conf
 
-sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
+#sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
 
 #Added to install the debug tool packages
 echo 'RDK_TOOLS_PACKAGES = ""' >> conf/local.conf

--- a/setup-environment
+++ b/setup-environment
@@ -158,6 +158,7 @@ esac
 sed -e "s/##DISTRO_CODENAME##/$_DISTRO_CODENAME/g" \
     -i conf/local.conf
 
+export MW_LAYER_BUILD_TYPE="MW_DEV"
 sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
 
 #Added to install the debug tool packages

--- a/setup-environment
+++ b/setup-environment
@@ -123,6 +123,7 @@ fi
 
 if [ -f "${_PWD_PREV}/../manifest_vars.conf" ];
 then
+        echo "MW_LAYER_BUILD_TYPE = \"${MW_LAYER_BUILD_TYPE}\"" >> ${_PWD_PREV}/../manifest_vars.conf
         mv ${_PWD_PREV}/../manifest_vars.conf ${_BUILDDIR}/conf/manifest_vars.conf
 fi
 
@@ -156,6 +157,8 @@ esac
 
 sed -e "s/##DISTRO_CODENAME##/$_DISTRO_CODENAME/g" \
     -i conf/local.conf
+
+sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
 
 #Added to install the debug tool packages
 echo 'RDK_TOOLS_PACKAGES = ""' >> conf/local.conf

--- a/setup-environment
+++ b/setup-environment
@@ -17,7 +17,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-#export MW_LAYER_BUILD_TYPE="MW_DEV"
+export MW_LAYER_BUILD_TYPE="MW_DEV"
 
 
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/setup-environment
+++ b/setup-environment
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-export MW_LAYER_BUILD_TYPE="MW_DEV"
+#export MW_LAYER_BUILD_TYPE="MW_DEV"
 
 
 _PWD_PREV=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/setup-environment
+++ b/setup-environment
@@ -159,7 +159,7 @@ sed -e "s/##DISTRO_CODENAME##/$_DISTRO_CODENAME/g" \
     -i conf/local.conf
 
 export MW_LAYER_BUILD_TYPE="MW_DEV"
-sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
+#sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
 
 #Added to install the debug tool packages
 echo 'RDK_TOOLS_PACKAGES = ""' >> conf/local.conf


### PR DESCRIPTION
Reason for change: Premerge CI integrate middleware development layer to image assembler manifest
Test Procedure: None
Risks: Low
Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>
