### PR TITLE
RDKEMW-3037: Premerge CI : integrate middleware development layer to …

### DIFF
--- a/export_manifest_path.sh
+++ b/export_manifest_path.sh
@@ -27,6 +27,19 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 repo_forall=$SCRIPT_DIR/repo_forall.sh
 tmp_env_file=$(mktemp)
 repo forall -c "$repo_forall >> $tmp_env_file"
+# Pre-process MANIFEST_PATH_BBLAYERS_TEMPLATE to support dev and feed support in the image assembler
+manifest_lines=$(grep '^export MANIFEST_PATH_BBLAYERS_TEMPLATE=' "$tmp_env_file")
+count=$(echo "$manifest_lines" | wc -l)
+if [ "$count" -gt 1 ]; then
+    chosen_line=$(echo "$manifest_lines" | grep 'meta-rdk-images')
+    if [ -z "$chosen_line" ]; then
+        echo "Bug: Duplicated variable(s) - "
+    else
+        # Remove all existing lines and append only the chosen one
+        sed -i '/^export MANIFEST_PATH_BBLAYERS_TEMPLATE=/d' "$tmp_env_file"
+        echo "$chosen_line" >> "$tmp_env_file"
+    fi
+fi
 duplicated_variables=`cat $tmp_env_file | grep -v 'PATH=' | sed 's|=.*$||g' | sort | uniq -c | grep -v '1 export' | sed 's|^.*export ||g'`
 if [ ! -z "$duplicated_variables" ]; then
   echo

--- a/setup-environment
+++ b/setup-environment
@@ -123,6 +123,7 @@ fi
 
 if [ -f "${_PWD_PREV}/../manifest_vars.conf" ];
 then
+        echo "MW_LAYER_BUILD_TYPE = \"${MW_LAYER_BUILD_TYPE}\"" >> ${_PWD_PREV}/../manifest_vars.conf
         mv ${_PWD_PREV}/../manifest_vars.conf ${_BUILDDIR}/conf/manifest_vars.conf
 fi
 
@@ -156,6 +157,8 @@ esac
 
 sed -e "s/##DISTRO_CODENAME##/$_DISTRO_CODENAME/g" \
     -i conf/local.conf
+
+sed -e "s/##MW_LAYER_BUILD_TYPE##/${MW_LAYER_BUILD_TYPE}/g" -i conf/local.conf
 
 #Added to install the debug tool packages
 echo 'RDK_TOOLS_PACKAGES = ""' >> conf/local.conf


### PR DESCRIPTION
…image assembler

Reason for change:
	 Premerge CI : integrate middleware development layer to image assembler manifest

Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com> (cherry picked from commit 369a0579273ec908b6934c40a896d8e1ecdcf43b)