### PR TITLE
RDKE-979 : standardize the TARGET_VENDOR variable with -rdk

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -194,7 +194,7 @@ echo "# Added support for generating debugfs " >> conf/local.conf
 echo "IMAGE_GEN_DEBUGFS = \"$DEBUGFS\"" >> conf/local.conf
 
 # Standardize the TARGET_VENDOR variable
-if [ -z $TARGET_VENDOR ]; then
+if [ -z "$TARGET_VENDOR" ]; then
     TARGET_VENDOR="-rdk"
 fi
 echo "# Standardize the TARGET_VENDOR variable" >> conf/local.conf

--- a/setup-environment
+++ b/setup-environment
@@ -193,6 +193,15 @@ fi
 echo "# Added support for generating debugfs " >> conf/local.conf
 echo "IMAGE_GEN_DEBUGFS = \"$DEBUGFS\"" >> conf/local.conf
 
+# Standardize the TARGET_VENDOR variable
+if [ -z $TARGET_VENDOR ]; then
+    TARGET_VENDOR="-rdk"
+fi
+echo "# Standardize the TARGET_VENDOR variable" >> conf/local.conf
+echo "# The TARGET_VENDOR variable is used to generate the folder structure for toolchain components." >> conf/local.conf
+echo "TARGET_VENDOR = \"$TARGET_VENDOR\"" >> conf/local.conf
+
+
 if [ -f ${_PWD_PREV}/../auto.conf ]; then
     ln -s ${_PWD_PREV}/../auto.conf conf/auto.conf
 fi


### PR DESCRIPTION
Standardize the TARGET_VENDOR variable
The TARGET_VENDOR variable is used to generate the folder structure for toolchain components.
STAGING_BINDIR_TOOLCHAIN = "${STAGING_DIR_NATIVE}${bindir_native}/${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS}".
To ensure that the prebuilt libraries are usable across all stack layers, we should standardize the TARGET_VENDOR value across the entire system.
If we do not use a common value for this variable, we won't be able to use the toolchain's prebuilt libraries, such as libgcc.